### PR TITLE
Fix/gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 db.sqlite3
+venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .env
 db.sqlite3
 venv
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
Se excluyeron los archivos de caché de Python (`__pycache__`, `.pyc`) y la carpeta `venv/` en el archivo `.gitignore` para evitar subir datos innecesarios o sensibles al repositorio.
